### PR TITLE
Fix Generator vmin_pu/vmax_pu setters not persisting to C engine

### DIFF
--- a/src/py_dss_interface/models/Generators/GeneratorsF.py
+++ b/src/py_dss_interface/models/Generators/GeneratorsF.py
@@ -52,10 +52,14 @@ class GeneratorsF(Base):
         return float(self._dss_obj.GeneratorsF(ctypes.c_int32(10), ctypes.c_double(0)))
 
     def _vmax_pu_write(self, argument: float) -> float:
-        return float(self._dss_obj.GeneratorsF(ctypes.c_int32(11), ctypes.c_double(argument)))
+        from py_dss_interface.models.Text.Text import Text
+        Text(self._dss_obj).text(f"Generator.{self.name}.Vmaxpu={argument}")
+        return argument
 
     def _vmin_pu(self) -> float:
         return float(self._dss_obj.GeneratorsF(ctypes.c_int32(12), ctypes.c_double(0)))
 
     def _vmin_pu_write(self, argument: float) -> float:
-        return float(self._dss_obj.GeneratorsF(ctypes.c_int32(13), ctypes.c_double(argument)))
+        from py_dss_interface.models.Text.Text import Text
+        Text(self._dss_obj).text(f"Generator.{self.name}.Vminpu={argument}")
+        return argument


### PR DESCRIPTION
## Summary

- **Bug:** `dss.generators.vmin_pu` and `dss.generators.vmax_pu` property setters call `GeneratorsF` with C API indices 11/13, but the C library handler for those indices doesn't write to the active Generator object — it only echoes the parameter back. This causes **silent data corruption** in power flow results (OpenDSS uses defaults 0.90/1.10 instead of the intended values).
- **Fix:** Replace the broken C API calls in `_vmax_pu_write` and `_vmin_pu_write` with text command workarounds (`Generator.<name>.Vmaxpu=<value>` / `Vminpu=<value>`), following the same pattern used elsewhere (e.g., `LoadShapesV.py`, `SettingsV.py`).
- Read operations (indices 10/12) are unaffected and remain unchanged.

## Reproduction

```python
dss.generators.name = "sgen_0"
dss.generators.vmin_pu = 0.0

# Getter looks OK:
print(dss.generators.vmin_pu)                    # → 0.0

# But the C engine was NOT updated:
print(dss.text("? Generator.sgen_0.Vminpu"))     # → 0.90 (default!)
```

After this fix, the text command correctly returns `0.0`.

## Root cause

The bug is in the OpenDSS C library (`libOpenDSSC.so`), not in py-dss-interface's Python code. The `GeneratorsF` function handler for parameter indices 11 and 13 reads the argument but doesn't assign it to the active Generator's `Vmaxpu`/`Vminpu` fields. The equivalent `DSSLoadsF` handler (indices 29/35) works correctly for loads.

## Test plan

- [x] Verified fix with manual test: set `vmin_pu=0.0`, `vmax_pu=2.0`, confirmed via text command read-back
- [ ] Existing tests in `test_generators.py` (note: test suite has pre-existing setup issues on Linux due to missing `.so` in `linux/cpp/` directory — not related to this change)